### PR TITLE
fix: Fix misspellings

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,3 @@ Prefer [Discord](https://discord.gg/sismo) or [Twitter](https://twitter.com/sism
 
 <br/>
 <img src="https://static.sismo.io/readme/bottom-main.png" alt="bottom" width="100%" >
-

--- a/contracts/attesters/hydra-s1/HydraS1AccountboundAttester.sol
+++ b/contracts/attesters/hydra-s1/HydraS1AccountboundAttester.sol
@@ -21,7 +21,7 @@ import {HydraS1SimpleAttester, IAttester, HydraS1Lib, HydraS1ProofData, HydraS1C
  * The Hydra-S1 Simple Attester contract is inherited and holds the complex Hydra S1 verification logic.
  * Request verification alongside proof verification is already implemented in the inherited HydraS1SimpleAttester, along with the buildAttestations logic.
  * However, we override the buildAttestations function to encode the nullifier and its burn count in the user attestation.
- * The _beforeRecordAttestations is also overriden to fit the Accountbound logic.
+ * The _beforeRecordAttestations is also overridden to fit the Accountbound logic.
  * We invite readers to refer to:
  *    - https://hydra-s1.docs.sismo.io for a full guide through the Hydra-S1 ZK Attestations
  *    - https://hydra-s1-circuits.docs.sismo.io for circuits, prover and verifiers of Hydra-S1
@@ -38,7 +38,7 @@ import {HydraS1SimpleAttester, IAttester, HydraS1Lib, HydraS1ProofData, HydraS1C
  * - Nullified
  *   Each source account gets one nullifier per claim (i.e only one attestation per source account per claim)
  *   While semaphore/ tornado cash are using the following notations: nullifierHash = hash(IdNullifier, externalNullifier)
- *   We prefered to use the naming 'nullifier' instead of 'nullifierHash' in our contracts and documentation.
+ *   We preferred to use the naming 'nullifier' instead of 'nullifierHash' in our contracts and documentation.
  *   We also renamed 'IdNullifier' in 'sourceSecret' (the secret tied to a source account) and we kept the 'externalNullifier' notation.
  *   Finally, here is our notations at Sismo: nullifier = hash(sourceSecret, externalNullifier)
 

--- a/contracts/core/Attester.sol
+++ b/contracts/core/Attester.sol
@@ -18,7 +18,7 @@ import {Request, Attestation, AttestationData} from './libs/Structs.sol';
  
  * - generateAttestations(request, proof) => will write attestations in the registry
  * 1. (MANDATORY) Implement the buildAttestations() view function which generate attestations from user request
- * 2. (MANDATORY) Implement teh _verifyRequest() internal function where to write checks
+ * 2. (MANDATORY) Implement the _verifyRequest() internal function where to write checks
  * 3. (OPTIONAL)  Override _beforeRecordAttestations and _afterRecordAttestations hooks
 
  * - deleteAttestations(collectionId, owner, proof) => will delete attestations in the registry

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "prettier": "prettier --write 'contracts/**/*.sol'",
     "chain": "hardhat node",
     "storage-layout": "hardhat print-storage-layout",
-    "deploy:local": "rm -rf deployments/local && hardhat deploy-full-local  --network local"
+    "deploy:local": "rm -rf deployments/local && hardhat deploy-full-local --network local"
   },
   "devDependencies": {
     "@nomiclabs/hardhat-etherscan": "^3.0.1",
@@ -32,7 +32,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "pretty-quick --staged --pattern 'test/**/*.ts'  --pattern 'tasks/**/*.ts' --pattern 'contracts/**/*.sol'"
+      "pre-commit": "pretty-quick --staged --pattern 'test/**/*.ts' --pattern 'tasks/**/*.ts' --pattern 'contracts/**/*.sol'"
     }
   },
   "dependencies": {

--- a/tasks/helpers/authorizations/ownable-transfer-ownership.task.ts
+++ b/tasks/helpers/authorizations/ownable-transfer-ownership.task.ts
@@ -30,7 +30,7 @@ async function ownableTransferOwnership(
   if (currentOwner.toLowerCase() === newOwner.toLowerCase()) {
     if (options?.log || options?.manualConfirm) {
       console.log(`
-    * CurrentOwner(${currentOwner}) is already the targetted owner. Nothing to do, exiting.
+    * CurrentOwner(${currentOwner}) is already the targeted owner. Nothing to do, exiting.
     `);
     }
     return;
@@ -46,7 +46,7 @@ async function ownableTransferOwnership(
     );
   }
 
-  // transfering ownership section
+  // transferring ownership section
   const actionTransferOwnership = {
     currentOwner,
     newOwner,


### PR DESCRIPTION
This PR fixes misspellings in the codes (and removes extra whitespace).

## Motivation
For maintenance and clarity.
I found some misspellings when I was reading the codes.

## Solution

Ran the following command using https://github.com/client9/misspell

```shell
misspell -w .
```